### PR TITLE
Task #18: Implement Timer GenServer — core start/tick/complete

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -35,7 +35,7 @@
 
 ## Phase 4: Timer GenServer
 
-- [ ] #18 Implement Timer GenServer — core start/tick/complete
+- [x] #18 Implement Timer GenServer — core start/tick/complete
 - [ ] #19 Add pause/resume/cancel to Timer GenServer
 - [ ] #20 Implement break logic in Timer GenServer
 - [ ] #21 Add Timer to supervision tree

--- a/lib/pomodo_rob/pomodoro/timer.ex
+++ b/lib/pomodo_rob/pomodoro/timer.ex
@@ -1,0 +1,147 @@
+defmodule PomodoRob.Pomodoro.Timer do
+  @moduledoc """
+  GenServer that manages a pomodoro timer countdown.
+
+  Ticks every second via `Process.send_after/3`. When the countdown
+  reaches zero the session is persisted to the database and a
+  `:completed` broadcast is sent over PubSub.
+
+  ## State
+
+      %{
+        status:            :idle | :running | :completed,
+        remaining_seconds: non_neg_integer(),
+        category_id:       integer() | nil,
+        started_at:        DateTime.t() | nil,
+        session_count:     non_neg_integer()
+      }
+  """
+
+  use GenServer
+
+  alias PomodoRob.Pomodoro
+
+  @pubsub PomodoRob.PubSub
+  @topic "timer"
+
+  # ── Client API ──────────────────────────────────────────────────────
+
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Starts a new pomodoro timer.
+
+  `category_id` may be `nil`. `duration_minutes` is the length of the
+  session in minutes.
+  """
+  def start_timer(category_id, duration_minutes, name \\ __MODULE__) do
+    GenServer.call(name, {:start_timer, category_id, duration_minutes})
+  end
+
+  @doc "Returns the current timer state as a map."
+  def get_state(name \\ __MODULE__) do
+    GenServer.call(name, :get_state)
+  end
+
+  @doc "Returns the PubSub topic used for timer broadcasts."
+  def topic, do: @topic
+
+  # ── Server callbacks ────────────────────────────────────────────────
+
+  @impl true
+  def init(_opts) do
+    {:ok, initial_state()}
+  end
+
+  @impl true
+  def handle_call({:start_timer, _category_id, _duration}, _from, %{status: :running} = state) do
+    {:reply, {:error, :already_running}, state}
+  end
+
+  def handle_call({:start_timer, category_id, duration_minutes}, _from, state) do
+    remaining = duration_minutes * 60
+
+    new_state = %{
+      state
+      | status: :running,
+        remaining_seconds: remaining,
+        category_id: category_id,
+        started_at: DateTime.utc_now()
+    }
+
+    schedule_tick()
+    broadcast(new_state)
+
+    {:reply, :ok, new_state}
+  end
+
+  @impl true
+  def handle_call(:get_state, _from, state) do
+    {:reply, state, state}
+  end
+
+  @impl true
+  def handle_info(:tick, %{status: :running, remaining_seconds: remaining} = state)
+      when remaining <= 1 do
+    new_state = complete_session(state)
+    broadcast(new_state)
+    {:noreply, new_state}
+  end
+
+  def handle_info(:tick, %{status: :running} = state) do
+    new_state = %{state | remaining_seconds: state.remaining_seconds - 1}
+    schedule_tick()
+    broadcast(new_state)
+    {:noreply, new_state}
+  end
+
+  def handle_info(:tick, state) do
+    # Ignore stale ticks when not running
+    {:noreply, state}
+  end
+
+  # ── Private helpers ─────────────────────────────────────────────────
+
+  defp initial_state do
+    %{
+      status: :idle,
+      remaining_seconds: 0,
+      category_id: nil,
+      started_at: nil,
+      session_count: 0
+    }
+  end
+
+  defp schedule_tick do
+    Process.send_after(self(), :tick, 1_000)
+  end
+
+  defp complete_session(state) do
+    now = DateTime.utc_now()
+    duration = DateTime.diff(now, state.started_at, :second)
+
+    attrs = %{
+      duration: duration,
+      started_at: state.started_at,
+      completed_at: now,
+      status: "completed",
+      category_id: state.category_id
+    }
+
+    {:ok, _session} = Pomodoro.create_session(attrs)
+
+    %{
+      state
+      | status: :completed,
+        remaining_seconds: 0,
+        session_count: state.session_count + 1
+    }
+  end
+
+  defp broadcast(state) do
+    Phoenix.PubSub.broadcast(@pubsub, @topic, {:timer_update, state})
+  end
+end

--- a/lib/pomodo_rob/pomodoro/timer.ex
+++ b/lib/pomodo_rob/pomodoro/timer.ex
@@ -19,6 +19,8 @@ defmodule PomodoRob.Pomodoro.Timer do
 
   use GenServer
 
+  require Logger
+
   alias PomodoRob.Pomodoro
 
   @pubsub PomodoRob.PubSub
@@ -61,6 +63,11 @@ defmodule PomodoRob.Pomodoro.Timer do
     {:reply, {:error, :already_running}, state}
   end
 
+  def handle_call({:start_timer, _category_id, duration}, _from, state)
+      when duration <= 0 do
+    {:reply, {:error, :invalid_duration}, state}
+  end
+
   def handle_call({:start_timer, category_id, duration_minutes}, _from, state) do
     remaining = duration_minutes * 60
 
@@ -84,18 +91,19 @@ defmodule PomodoRob.Pomodoro.Timer do
   end
 
   @impl true
-  def handle_info(:tick, %{status: :running, remaining_seconds: remaining} = state)
-      when remaining <= 1 do
-    new_state = complete_session(state)
-    broadcast(new_state)
-    {:noreply, new_state}
-  end
-
   def handle_info(:tick, %{status: :running} = state) do
-    new_state = %{state | remaining_seconds: state.remaining_seconds - 1}
-    schedule_tick()
-    broadcast(new_state)
-    {:noreply, new_state}
+    new_remaining = state.remaining_seconds - 1
+
+    if new_remaining <= 0 do
+      new_state = complete_session(state)
+      broadcast(new_state)
+      {:noreply, new_state}
+    else
+      new_state = %{state | remaining_seconds: new_remaining}
+      schedule_tick()
+      broadcast(new_state)
+      {:noreply, new_state}
+    end
   end
 
   def handle_info(:tick, state) do
@@ -131,7 +139,13 @@ defmodule PomodoRob.Pomodoro.Timer do
       category_id: state.category_id
     }
 
-    {:ok, _session} = Pomodoro.create_session(attrs)
+    case Pomodoro.create_session(attrs) do
+      {:ok, _session} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Timer: failed to persist session: #{inspect(reason)}")
+    end
 
     %{
       state


### PR DESCRIPTION
## Summary
- Add `PomodoRob.Pomodoro.Timer` GenServer with start/tick/complete lifecycle
- Timer ticks every second via `Process.send_after`, auto-completes and persists session at zero
- Broadcasts state changes over Phoenix PubSub on the `"timer"` topic
- State tracks: status, remaining_seconds, category_id, started_at, session_count

## Test plan
- [ ] `mix compile --warnings-as-errors` passes
- [ ] `mix test` passes (80 tests, 0 failures)
- [ ] `mix format --check-formatted` passes
- [ ] `mix credo --strict` passes

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)