### PR TITLE
Task #19: Add pause/resume/cancel to Timer GenServer

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -36,7 +36,7 @@
 ## Phase 4: Timer GenServer
 
 - [x] #18 Implement Timer GenServer — core start/tick/complete
-- [ ] #19 Add pause/resume/cancel to Timer GenServer
+- [x] #19 Add pause/resume/cancel to Timer GenServer
 - [ ] #20 Implement break logic in Timer GenServer
 - [ ] #21 Add Timer to supervision tree
 - [ ] #22 Write tests for Timer GenServer

--- a/lib/pomodo_rob/pomodoro/timer.ex
+++ b/lib/pomodo_rob/pomodoro/timer.ex
@@ -14,7 +14,9 @@ defmodule PomodoRob.Pomodoro.Timer do
         category_id:       integer() | nil,
         started_at:        DateTime.t() | nil,
         session_count:     non_neg_integer(),
-        tick_ref:          reference() | nil
+        tick_ref:          reference() | nil,
+        paused_seconds:    non_neg_integer(),
+        paused_at:         DateTime.t() | nil
       }
   """
 
@@ -105,7 +107,7 @@ defmodule PomodoRob.Pomodoro.Timer do
   @impl true
   def handle_call(:pause_timer, _from, %{status: :running, tick_ref: ref} = state) do
     cancel_tick(ref)
-    new_state = %{state | status: :paused, tick_ref: nil}
+    new_state = %{state | status: :paused, tick_ref: nil, paused_at: DateTime.utc_now()}
     broadcast(new_state)
     {:reply, :ok, new_state}
   end
@@ -116,7 +118,16 @@ defmodule PomodoRob.Pomodoro.Timer do
 
   @impl true
   def handle_call(:resume_timer, _from, %{status: :paused} = state) do
-    new_state = %{state | status: :running, tick_ref: schedule_tick()}
+    pause_duration = DateTime.diff(DateTime.utc_now(), state.paused_at, :second)
+
+    new_state = %{
+      state
+      | status: :running,
+        tick_ref: schedule_tick(),
+        paused_seconds: state.paused_seconds + pause_duration,
+        paused_at: nil
+    }
+
     broadcast(new_state)
     {:reply, :ok, new_state}
   end
@@ -172,7 +183,9 @@ defmodule PomodoRob.Pomodoro.Timer do
       category_id: nil,
       started_at: nil,
       session_count: 0,
-      tick_ref: nil
+      tick_ref: nil,
+      paused_seconds: 0,
+      paused_at: nil
     }
   end
 
@@ -189,7 +202,8 @@ defmodule PomodoRob.Pomodoro.Timer do
 
   defp complete_session(state) do
     now = DateTime.utc_now()
-    duration = DateTime.diff(now, state.started_at, :second)
+    wall_clock = DateTime.diff(now, state.started_at, :second)
+    duration = wall_clock - state.paused_seconds
 
     attrs = %{
       duration: duration,

--- a/lib/pomodo_rob/pomodoro/timer.ex
+++ b/lib/pomodo_rob/pomodoro/timer.ex
@@ -9,11 +9,12 @@ defmodule PomodoRob.Pomodoro.Timer do
   ## State
 
       %{
-        status:            :idle | :running | :completed,
+        status:            :idle | :running | :paused | :completed,
         remaining_seconds: non_neg_integer(),
         category_id:       integer() | nil,
         started_at:        DateTime.t() | nil,
-        session_count:     non_neg_integer()
+        session_count:     non_neg_integer(),
+        tick_ref:          reference() | nil
       }
   """
 
@@ -43,6 +44,21 @@ defmodule PomodoRob.Pomodoro.Timer do
     GenServer.call(name, {:start_timer, category_id, duration_minutes})
   end
 
+  @doc "Pauses a running timer, preserving remaining time."
+  def pause_timer(name \\ __MODULE__) do
+    GenServer.call(name, :pause_timer)
+  end
+
+  @doc "Resumes a paused timer."
+  def resume_timer(name \\ __MODULE__) do
+    GenServer.call(name, :resume_timer)
+  end
+
+  @doc "Cancels the current timer without saving the session."
+  def cancel_timer(name \\ __MODULE__) do
+    GenServer.call(name, :cancel_timer)
+  end
+
   @doc "Returns the current timer state as a map."
   def get_state(name \\ __MODULE__) do
     GenServer.call(name, :get_state)
@@ -59,7 +75,8 @@ defmodule PomodoRob.Pomodoro.Timer do
   end
 
   @impl true
-  def handle_call({:start_timer, _category_id, _duration}, _from, %{status: :running} = state) do
+  def handle_call({:start_timer, _category_id, _duration}, _from, %{status: status} = state)
+      when status in [:running, :paused] do
     {:reply, {:error, :already_running}, state}
   end
 
@@ -76,13 +93,49 @@ defmodule PomodoRob.Pomodoro.Timer do
       | status: :running,
         remaining_seconds: remaining,
         category_id: category_id,
-        started_at: DateTime.utc_now()
+        started_at: DateTime.utc_now(),
+        tick_ref: schedule_tick()
     }
 
-    schedule_tick()
     broadcast(new_state)
 
     {:reply, :ok, new_state}
+  end
+
+  @impl true
+  def handle_call(:pause_timer, _from, %{status: :running, tick_ref: ref} = state) do
+    cancel_tick(ref)
+    new_state = %{state | status: :paused, tick_ref: nil}
+    broadcast(new_state)
+    {:reply, :ok, new_state}
+  end
+
+  def handle_call(:pause_timer, _from, state) do
+    {:reply, {:error, :not_running}, state}
+  end
+
+  @impl true
+  def handle_call(:resume_timer, _from, %{status: :paused} = state) do
+    new_state = %{state | status: :running, tick_ref: schedule_tick()}
+    broadcast(new_state)
+    {:reply, :ok, new_state}
+  end
+
+  def handle_call(:resume_timer, _from, state) do
+    {:reply, {:error, :not_paused}, state}
+  end
+
+  @impl true
+  def handle_call(:cancel_timer, _from, %{status: status, tick_ref: ref} = state)
+      when status in [:running, :paused] do
+    cancel_tick(ref)
+    new_state = %{initial_state() | session_count: state.session_count}
+    broadcast(new_state)
+    {:reply, :ok, new_state}
+  end
+
+  def handle_call(:cancel_timer, _from, state) do
+    {:reply, {:error, :not_active}, state}
   end
 
   @impl true
@@ -99,8 +152,7 @@ defmodule PomodoRob.Pomodoro.Timer do
       broadcast(new_state)
       {:noreply, new_state}
     else
-      new_state = %{state | remaining_seconds: new_remaining}
-      schedule_tick()
+      new_state = %{state | remaining_seconds: new_remaining, tick_ref: schedule_tick()}
       broadcast(new_state)
       {:noreply, new_state}
     end
@@ -119,12 +171,20 @@ defmodule PomodoRob.Pomodoro.Timer do
       remaining_seconds: 0,
       category_id: nil,
       started_at: nil,
-      session_count: 0
+      session_count: 0,
+      tick_ref: nil
     }
   end
 
   defp schedule_tick do
     Process.send_after(self(), :tick, 1_000)
+  end
+
+  defp cancel_tick(nil), do: :ok
+
+  defp cancel_tick(ref) do
+    Process.cancel_timer(ref)
+    :ok
   end
 
   defp complete_session(state) do
@@ -151,7 +211,8 @@ defmodule PomodoRob.Pomodoro.Timer do
       state
       | status: :completed,
         remaining_seconds: 0,
-        session_count: state.session_count + 1
+        session_count: state.session_count + 1,
+        tick_ref: nil
     }
   end
 


### PR DESCRIPTION
## Summary
- Add `pause_timer/0`, `resume_timer/0`, and `cancel_timer/0` to the Timer GenServer
- Pause stops the tick loop and preserves remaining time; resume restarts ticking
- Cancel discards the session without saving to the database
- Track `tick_ref` to properly cancel scheduled ticks, preventing stale messages
- All state changes broadcast over PubSub
- Reject `start_timer` when timer is paused (same as running)

## Test plan
- [ ] `mix compile --warnings-as-errors` passes
- [ ] `mix test` — all 80 tests pass
- [ ] `mix format --check-formatted` passes
- [ ] `mix credo --strict` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)